### PR TITLE
feat: use WordPress plugin dependency feature

### DIFF
--- a/.github/workflows/standards-and-tests.yml
+++ b/.github/workflows/standards-and-tests.yml
@@ -17,12 +17,12 @@ jobs:
       matrix:
         php: [ 8.1, 8.2 ]
         os: [ubuntu-20.04]
-        wordpress: [6.2, latest]
+        wordpress: ['6.5', latest]
         include:
           - experimental: true
           - experimental: false
             php: 8.1
-            wordpress: 6.2
+            wordpress: '6.5'
     name: Tests - PHP ${{ matrix.php }} - WP ${{ matrix.wordpress }}
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   "require-dev": {
     "phpcompatibility/php-compatibility": "^9.3",
     "pressbooks/coding-standards": "^1.1",
-    "yoast/phpunit-polyfills": "^1.0.1"
+    "yoast/phpunit-polyfills": "^1.1"
   },
   "scripts": {
     "test": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ad4b14b2bc2f57bf9922354c9bc157ae",
+    "content-hash": "9165a879836980ab6ecc84442cabdc08",
     "packages": [
         {
             "name": "composer/installers",
@@ -2453,16 +2453,16 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "1.0.5",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "3b59adeef77fb1c03ff5381dbb9d68b0aaff3171"
+                "reference": "224e4a1329c03d8bad520e3fc4ec980034a4b212"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/3b59adeef77fb1c03ff5381dbb9d68b0aaff3171",
-                "reference": "3b59adeef77fb1c03ff5381dbb9d68b0aaff3171",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/224e4a1329c03d8bad520e3fc4ec980034a4b212",
+                "reference": "224e4a1329c03d8bad520e3fc4ec980034a4b212",
                 "shasum": ""
             },
             "require": {
@@ -2509,7 +2509,7 @@
                 "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2023-03-30T23:39:05+00:00"
+            "time": "2023-08-19T14:25:08+00:00"
         }
     ],
     "aliases": [],
@@ -2521,5 +2521,5 @@
         "php": "^8.1"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/excalibur.php
+++ b/excalibur.php
@@ -4,6 +4,8 @@ Plugin Name: Excalibur
 Plugin URI: https://github.com/pressbooks/excalibur/
 GitHub Plugin URI: pressbooks/excalibur
 Release Asset: true
+Requires at least: 6.5
+Requires Plugins: pressbooks
 Description: Excalibur is a SWORD protocol client for Pressbooks.
 Version: 0.7.0
 Author: Pressbooks (Book Oven Inc.)
@@ -13,19 +15,6 @@ Text Domain: excalibur
 License: GPL v3 or later
 Network: True
 */
-
-// -------------------------------------------------------------------------------------------------------------------
-// Check minimum requirements
-// -------------------------------------------------------------------------------------------------------------------
-
-if ( ! function_exists( 'pb_meets_minimum_requirements' ) && ! @include_once( WP_PLUGIN_DIR . '/pressbooks/compatibility.php' ) ) { // @codingStandardsIgnoreLine
-	add_action('admin_notices', function () {
-		echo '<div id="message" role="alert" class="error fade"><p>' . __( 'Cannot find Pressbooks install.', 'excalibur' ) . '</p></div>';
-	});
-	return;
-} elseif ( ! pb_meets_minimum_requirements() ) {
-	return;
-}
 
 // -------------------------------------------------------------------------------------------------------------------
 // Class autoloader

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -14,6 +14,8 @@ require_once $_tests_dir . '/includes/functions.php';
 function _manually_load_plugin() {
 	require_once( __DIR__ . '/../../pressbooks/hm-autoloader.php' );
 	require_once( __DIR__ . '/../../pressbooks/pressbooks.php' );
+	require_once( __DIR__ . '/../../pressbooks/requires.php' );
+	require_once( __DIR__ . '/../../pressbooks/requires-admin.php' );
 	require_once( __DIR__ . '/../excalibur.php' );
 }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,6 +12,7 @@ require_once $_tests_dir . '/includes/functions.php';
  * Manually load the plugin being tested.
  */
 function _manually_load_plugin() {
+	require_once( __DIR__ . '/../../pressbooks/hm-autoloader.php' );
 	require_once( __DIR__ . '/../../pressbooks/pressbooks.php' );
 	require_once( __DIR__ . '/../excalibur.php' );
 }


### PR DESCRIPTION
WordPress 6.5 (coming Tuesday) introduces [plugin dependencies](https://make.wordpress.org/core/2024/03/05/introducing-plugin-dependencies-in-wordpress-6-5/).

This means we can remove the `pb_meets_minimum_requirements` check.