### PR TITLE
chore: crowdin integration

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -1,0 +1,60 @@
+name: Crowdin Translations Sync
+
+on:
+  push:
+    branches:
+      - dev
+    paths:
+      - 'languages/excalibur.pot'
+
+  schedule:
+    - cron: '0 0 * * *'
+
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'Action to perform'
+        type: choice
+        options:
+          - Pull Translations
+          - Seed Translations
+        default: Pull Translations
+
+jobs:
+  upload-sources:
+    name: Upload Sources
+    if: github.event_name == 'push'
+    uses: pressbooks/reusable-workflows/.github/workflows/crowdin.yml@main
+    with:
+      action: upload
+      pot_file_path: languages/excalibur.pot
+      crowdin_branch_name: excalibur
+      base_branch: dev
+      project_type: private
+    secrets: inherit
+
+  download-translations:
+    name: Pull Translations
+    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'Pull Translations')
+    uses: pressbooks/reusable-workflows/.github/workflows/crowdin.yml@main
+    with:
+      action: download
+      pot_file_path: languages/excalibur.pot
+      languages_dir: languages/
+      crowdin_branch_name: excalibur
+      base_branch: dev
+      project_type: private
+    secrets: inherit
+
+  seed-translations:
+    name: Seed Translations
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'Seed Translations'
+    uses: pressbooks/reusable-workflows/.github/workflows/crowdin.yml@main
+    with:
+      action: seed
+      pot_file_path: languages/excalibur.pot
+      languages_dir: languages/
+      crowdin_branch_name: excalibur
+      base_branch: dev
+      project_type: private
+    secrets: inherit

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,19 @@
+"project_id_env": "CROWDIN_OPEN_PROJECT_ID"
+"api_token_env": "CROWDIN_API_SECRET"
+"pull_request_title": "chore(l10n): update languages"
+"preserve_hierarchy": true
+"files": [
+  {
+    "source": "/languages/excalibur.pot",
+    "dest": "/languages/excalibur.pot",
+    "translation": "/languages/excalibur-%locale_with_underscore%.po",
+    "languages_mapping": {
+      "locale_with_underscore": {
+        "es-ES": "es_ES",
+        "es-MX": "es_MX",
+        "fr": "fr_FR",
+        "fr-CA": "fr_CA"
+      }
+    }
+  }
+]

--- a/excalibur.php
+++ b/excalibur.php
@@ -42,3 +42,7 @@ require( __DIR__ . '/inc/protocol/swordv1/namespace.php' );
 if ( is_admin() ) {
 	$p = new \Excalibur\Dspace\Admin();
 }
+
+add_action('init', function () {
+	load_plugin_textdomain( 'excalibur', false, 'excalibur/languages/' );
+});


### PR DESCRIPTION
Issue: https://github.com/pressbooks/private/issues/2454

This pull request introduces automated workflows and configuration for Crowdin translation syncing, as well as an update to how translations are loaded in the plugin. The changes streamline the process for managing and updating translations by integrating Crowdin with GitHub Actions, and ensure that plugin translations are properly loaded in WordPress.

**Crowdin Integration and Automation:**

* Added `.github/workflows/crowdin.yml` to automate syncing of translation source files and pulling translations from Crowdin, including scheduled, manual, and push-based triggers.
* Introduced `crowdin.yml` configuration file to specify Crowdin project settings, file mappings, and language code mappings for supported locales.

**Translation Loading Improvements:**

* Updated `excalibur.php` to load the plugin's text domain on the `init` action, ensuring translations are available for WordPress internationalization.